### PR TITLE
made capitalization consistent

### DIFF
--- a/ui/narrative/methods/load_paired_end_reads_from_URL/display.yaml
+++ b/ui/narrative/methods/load_paired_end_reads_from_URL/display.yaml
@@ -36,7 +36,7 @@ parameters :
                 Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2
 
     rev_file_url :
-        ui-name : Reverse/Right Fasta/Fastq URL
+        ui-name : Reverse/Right FASTA/FASTQ URL
         short-hint : Second download link containing a single end library in FASTA/FASTQ format
         long-hint  : |
                 Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2
@@ -69,8 +69,8 @@ parameters :
 parameter-groups :
     urls_to_add :
         ui-name : URL(s)
-        short-hint : FASTQ file URL and output Reads file name
-        long-hint  : FASTQ file URL and output Reads file name
+        short-hint : FASTQ file URL and output reads filename
+        long-hint  : FASTQ file URL and output reads filename
 
 description : |
     <p> Upload a Paired End Library into your Narrative. </p>


### PR DESCRIPTION
why should it be FASTA/FASTQ for the forward reads parameter and Fasta/Fastq for the reverse?