### PR TITLE
PTV-1327 - accept /user_id and / as valid staging root names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 ###Release Notes
 
+**1.0.34**
+In the Batch Import apps, accept both /user_id and / as valid names of the root directory
+
 **1.0.33**
 restore visibility of Batch Import Apps up to beta
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.33
+    1.0.34
 
 owners:
     [tgu2, slebras]

--- a/lib/kb_uploadmethods/Utils/BatchUtil.py
+++ b/lib/kb_uploadmethods/Utils/BatchUtil.py
@@ -221,6 +221,10 @@ class BatchUtil:
         workspace_name = params.get('workspace_name')
         genome_set_name = params.get('genome_set_name')
 
+        if staging_subdir.startswith(self.user_id + '/' ):
+            temp = len(self.user_id) + 1
+            staging_subdir = staging_subdir[temp:]
+            
         genome_files = self._fetch_genome_files(staging_subdir)
 
         genome_objects = list()
@@ -283,6 +287,10 @@ class BatchUtil:
         workspace_name = params.get('workspace_name')
         assembly_set_name = params.get('assembly_set_name')
 
+        if staging_subdir.startswith(self.user_id + '/' ):
+            temp = len(self.user_id) + 1
+            staging_subdir = staging_subdir[temp:]
+        
         assembly_files = self._fetch_assembly_files(staging_subdir)
 
         assembly_objects = list()

--- a/test/batch_util_test.py
+++ b/test/batch_util_test.py
@@ -143,7 +143,7 @@ class kb_uploadmethodsTest(unittest.TestCase):
     @patch.object(DataFileUtil, "download_staging_file", side_effect=mock_download_staging_file)
     def test_batch_import_assemblies_from_staging(self, download_staging_file):
         input_params = {
-            'staging_subdir': 'test_batch',
+            'staging_subdir': self.user_id + '/test_batch',
             'workspace_name': self.getWsName(),
             'assembly_set_name': 'test_assembly_set_name'
         }


### PR DESCRIPTION
@tian - In the app "Batch Import from Staging" users frequently use /user_id as their root directory name because:
1) that is what it is called in Globus
2) that is what it is called when in the staging area.

This has resulted in multiple tickets. This modification will allow both the current value of / and the user expected value of /user_id as names of the root directory of the staging area.