### PR TITLE
PTV-1657 fix: enable upload of files larger than 2gb in compressed web files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get install -y gcc
 RUN pip install coverage==5.3.1 \
     && pip install dropbox==11.0.0 \
     && pip install requests --upgrade \
+    && pip install requests_toolbelt=0.9.1 \
     && ( [ $(pip show filemagic|grep -c filemagic) -eq 0 ] || pip uninstall -y filemagic ) \
     && pip install python-magic==0.4.18 \
     && pip install mock==4.0.3 \

--- a/lib/kb_uploadmethods/Utils/UnpackFileUtil.py
+++ b/lib/kb_uploadmethods/Utils/UnpackFileUtil.py
@@ -5,6 +5,7 @@ import time
 import uuid
 from configparser import SafeConfigParser
 import requests as _requests
+from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 import magic
 
@@ -38,14 +39,22 @@ class UnpackFileUtil:
         subdir_folder_str = '/' if not subdir_folder else '/{}'.format(subdir_folder)
         staging_service_host = self._staging_service_host()
         end_point = staging_service_host + '/upload'
-        headers = {'Authorization': self.token}
 
         files = {'destPath': subdir_folder_str}
 
         for file_path in file_path_list:
             files.update({'uploads': (os.path.basename(file_path), open(file_path, 'rb'))})
 
-            resp = _requests.post(end_point, headers=headers, files=files)
+            multipart_encoded = MultipartEncoder(files)
+
+            resp = _requests.post(end_point,
+                                  data=multipart_encoded,
+                                  headers={
+                                      'Authorization':
+                                      self.token,
+                                      'Content-Type':
+                                      multipart_encoded.content_type
+                                  })
 
             if resp.status_code != 200:
                 raise ValueError('Upload file {} failed.\nError Code: {}\n{}\n'


### PR DESCRIPTION
# Description of PR purpose/changes

- Introduces `requests_toolbelt` dependency for `MultipartEncoder` to allow streaming upload of files larger than 2GB between this service and staging service.

# Jira Ticket / Issue

<https://kbase-jira.atlassian.net/browse/PTV-1657>

-   [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions

-   Details for how to test the PR: 
    -   **Need help here, no existing tests for this part of the code, may require integration testing?**
-   [ ] Tests pass in Travis-CI and locally 

# Dev Checklist:

-   [-] My code follows the guidelines at <https://sites.google.com/truss.works/kbasetruss/development> 
    - this DNE
-   [x] I have performed a self-review of my own code
-   [-] I have commented my code, particularly in hard-to-understand areas
    - N/A, no functional change
-   [-] I have made corresponding changes to the documentation, including updating the README with app information changes
    - N/A
-   [x] My changes generate no new warnings
-   [-] I have added tests that prove my fix is effective or that my feature works
    -   **Need help here, no existing tests for this part of the code, may require integration testing?**
-   [-] New and existing tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

-   [ ] [Version has been bumped](https://semver.org/) in `kbase.yml`
-   [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
