### PR TITLE
DATAUP-477: Fix non-int fastq app from always specifing interleaved is true

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 ###Release Notes
 
+**1.0.48**
+Fix `import_fastq_noninterleaved...` app always specifying `interleaved=true`
+
 **1.0.47**
 Add support for uploading files > 2GB to the staging service
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.47
+    1.0.48
 
 owners:
-    [tgu2, slebras]
+    [tgu2, slebras, gaprice]

--- a/ui/narrative/methods/import_fastq_noninterleaved_as_reads_from_staging/spec.json
+++ b/ui/narrative/methods/import_fastq_noninterleaved_as_reads_from_staging/spec.json
@@ -186,7 +186,7 @@
           "target_property": "single_genome"
         },
         {
-          "constant_value": "0",
+          "constant_value": 0,
           "target_property": "interleaved"
         },
         {


### PR DESCRIPTION
# Description of PR purpose/changes

Fix non-int fastq app from always specifying interleaved is true,
which is a big problem for single end reads - they wind up being treated
as interleaved paired end reads.

I don't think there's any way to test this change other than
running in the narrative, but if I'm wrong I'm happy to add tests if someone
could point out the right place to add them.

I assume this'll work, but I'm not 100% sure its the fix without testing.

Also, it looks like we're using master as the branch where changes go
based on the branch history, but let me know if I should
rebase (and in that case we should sync master -> dev).

# Jira Ticket / Issue

https://kbase-jira.atlassian.net/browse/DATAUP-477

-   [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions

-   Details for how to test the PR: 
-   [x] Tests pass in Travis-CI and locally 

# Dev Checklist:

-   [x] My code follows the guidelines at <https://sites.google.com/truss.works/kbasetruss/development>
-   [x] I have performed a self-review of my own code
-   [n/a] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation, including updating the README with app information changes
-   [x] My changes generate no new warnings
-   [n/a] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing tests pass locally with my changes
-   [n/a] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

-   [x] [Version has been bumped](https://semver.org/) in `kbase.yml`
-   [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
