### PR TITLE
Modified UI spec of import_genbank_as_genome_from_staging and import_…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 ###Release Notes
 
+**1.0.49**
+Add dynamic dropdown boxes for scientific_name ui input to address conflicting scientific_name/taxon_id issues. The dynamic dropdown will connect to the re_api_search service to match the ncbi_taxon_id for the scientific_name user types into the input box.
+
 **1.0.48**
 Fix `import_fastq_noninterleaved...` app always specifying `interleaved=true`
 

--- a/kb_uploadmethods.spec
+++ b/kb_uploadmethods.spec
@@ -301,8 +301,6 @@ module kb_uploadmethods {
 
     release - Release or version number of the data
         per example Ensembl has numbered releases of all their data: Release 31
-    taxon_id - if defined, will try to link the Genome to the specified
-        taxonomy id in lieu of performing the lookup during upload
     generate_ids_if_needed - If field used for feature id is not there,
         generate ids (default behavior is raising an exception)
     generate_missing_genes - Generate gene feature for CDSs that do not have

--- a/kb_uploadmethods.spec
+++ b/kb_uploadmethods.spec
@@ -100,16 +100,13 @@ module kb_uploadmethods {
     gff_file: gff file containing predicted gene models and corresponding features
 
     Optional params:
-    ncbi_taxon_id - the numeric ID of the NCBI taxon to which this genome belongs. If this
-		is included scientific_name is ignored.
-    relation_engine_timestamp_ms - the timestamp to send to the Relation Engine when looking
-		up taxon information in milliseconds since the epoch.
-    scientific_name - the scientific name of the genome. Overridden by ncbi_taxon_id.
+    scientific_name - the scientific name of the genome. Overridden by NCBI taxon id.
+    taxon_id - the numeric ID of the NCBI taxon to which this genome belongs.
+               If defined, will try to link the Genome to the specified
+               taxonomy id in lieu of performing the lookup during upload
 
     source: Source Of The GFF File. Default to 'User'
     taxon_wsname - where the reference taxons are. Default to 'ReferenceTaxons'
-    taxon_id - if defined, will try to link the Genome to the specified
-        taxonomy id in lieu of performing the lookup during upload
     release: Release Or Version Of The Source Data
     genetic_code: Genetic Code For The Organism
     type: 'Reference', 'User upload', 'Representative'
@@ -128,10 +125,8 @@ module kb_uploadmethods {
     string release;
     int    genetic_code;
     string type;
-
     string generate_missing_genes;
-    int ncbi_taxon_id;
-    int relation_engine_timestamp_ms;
+
   } UploadFastaGFFMethodParams;
 
   typedef structure {
@@ -299,11 +294,11 @@ module kb_uploadmethods {
     source - Source of the file typically something like RefSeq or Ensembl
 
     optional params:
-    ncbi_taxon_id - the numeric ID of the NCBI taxon to which this genome belongs. If this
-		is included scientific_name is ignored.
-    relation_engine_timestamp_ms - the timestamp to send to the Relation Engine when looking
-		up taxon information in milliseconds since the epoch.
-    scientific_name - the scientific name of the genome. Overridden by ncbi_taxon_id.
+    scientific_name - the scientific name of the genome. Overridden by NCBI taxon id.
+    taxon_id - the numeric ID of the NCBI taxon to which this genome belongs.
+               If defined, will try to link the Genome to the specified
+               taxonomy id in lieu of performing the lookup during upload
+
     release - Release or version number of the data
         per example Ensembl has numbered releases of all their data: Release 31
     taxon_id - if defined, will try to link the Genome to the specified
@@ -330,8 +325,6 @@ module kb_uploadmethods {
     string taxon_id;
     string generate_ids_if_needed;
     string generate_missing_genes;
-    int ncbi_taxon_id;
-    int relation_engine_timestamp_ms;
   } GenbankToGenomeParams;
 
   typedef structure {

--- a/kb_uploadmethods.spec
+++ b/kb_uploadmethods.spec
@@ -100,7 +100,12 @@ module kb_uploadmethods {
     gff_file: gff file containing predicted gene models and corresponding features
 
     Optional params:
-    scientific_name: proper name for species, key for taxonomy lookup. Default to 'unknown_taxon'
+    ncbi_taxon_id - the numeric ID of the NCBI taxon to which this genome belongs. If this
+		is included scientific_name is ignored.
+    relation_engine_timestamp_ms - the timestamp to send to the Relation Engine when looking
+		up taxon information in milliseconds since the epoch.
+    scientific_name - the scientific name of the genome. Overridden by ncbi_taxon_id.
+
     source: Source Of The GFF File. Default to 'User'
     taxon_wsname - where the reference taxons are. Default to 'ReferenceTaxons'
     taxon_id - if defined, will try to link the Genome to the specified
@@ -123,7 +128,10 @@ module kb_uploadmethods {
     string release;
     int    genetic_code;
     string type;
+
     string generate_missing_genes;
+    int ncbi_taxon_id;
+    int relation_engine_timestamp_ms;
   } UploadFastaGFFMethodParams;
 
   typedef structure {
@@ -291,10 +299,13 @@ module kb_uploadmethods {
     source - Source of the file typically something like RefSeq or Ensembl
 
     optional params:
+    ncbi_taxon_id - the numeric ID of the NCBI taxon to which this genome belongs. If this
+		is included scientific_name is ignored.
+    relation_engine_timestamp_ms - the timestamp to send to the Relation Engine when looking
+		up taxon information in milliseconds since the epoch.
+    scientific_name - the scientific name of the genome. Overridden by ncbi_taxon_id.
     release - Release or version number of the data
         per example Ensembl has numbered releases of all their data: Release 31
-    scientific_name - will be used to set the scientific name of the genome
-        and link to a taxon
     taxon_id - if defined, will try to link the Genome to the specified
         taxonomy id in lieu of performing the lookup during upload
     generate_ids_if_needed - If field used for feature id is not there,
@@ -319,6 +330,8 @@ module kb_uploadmethods {
     string taxon_id;
     string generate_ids_if_needed;
     string generate_missing_genes;
+    int ncbi_taxon_id;
+    int relation_engine_timestamp_ms;
   } GenbankToGenomeParams;
 
   typedef structure {

--- a/kb_uploadmethods.spec
+++ b/kb_uploadmethods.spec
@@ -100,7 +100,7 @@ module kb_uploadmethods {
     gff_file: gff file containing predicted gene models and corresponding features
 
     Optional params:
-    scientific_name - the scientific name of the genome. Overridden by NCBI taxon id.
+    scientific_name - the scientific name of the genome.
     taxon_id - the numeric ID of the NCBI taxon to which this genome belongs.
                If defined, will try to link the Genome to the specified
                taxonomy id in lieu of performing the lookup during upload
@@ -294,7 +294,7 @@ module kb_uploadmethods {
     source - Source of the file typically something like RefSeq or Ensembl
 
     optional params:
-    scientific_name - the scientific name of the genome. Overridden by NCBI taxon id.
+    scientific_name - the scientific name of the genome.
     taxon_id - the numeric ID of the NCBI taxon to which this genome belongs.
                If defined, will try to link the Genome to the specified
                taxonomy id in lieu of performing the lookup during upload

--- a/kbase.yml
+++ b/kbase.yml
@@ -11,4 +11,4 @@ module-version:
     1.0.48
 
 owners:
-    [tgu2, slebras, gaprice]
+    [tgu2, slebras, gaprice, qzhang]

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.48
+    1.0.49
 
 owners:
     [tgu2, slebras, gaprice, qzhang]

--- a/lib/kb_uploadmethods/kb_uploadmethodsImpl.py
+++ b/lib/kb_uploadmethods/kb_uploadmethodsImpl.py
@@ -38,9 +38,9 @@ class kb_uploadmethods:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "1.0.44"
-    GIT_URL = "git@github.com:Tianhao-Gu/kb_uploadmethods.git"
-    GIT_COMMIT_HASH = "25e7a896377f5ec50bd15a27ade9f279cb16cd0b"
+    VERSION = "1.0.48"
+    GIT_URL = "https://github.com/kbaseapps/kb_uploadmethods.git"
+    GIT_COMMIT_HASH = "6b3b13149c785420a98c7e3c196e4528070b24f3"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -148,9 +148,13 @@ class kb_uploadmethods:
            workspace name/ID of the object For staging area: fasta_file:
            fasta file containing assembled contigs/chromosomes gff_file: gff
            file containing predicted gene models and corresponding features
-           Optional params: scientific_name: proper name for species, key for
-           taxonomy lookup. Default to 'unknown_taxon' source: Source Of The
-           GFF File. Default to 'User' taxon_wsname - where the reference
+           Optional params: ncbi_taxon_id - the numeric ID of the NCBI taxon
+           to which this genome belongs. If this is included scientific_name
+           is ignored. relation_engine_timestamp_ms - the timestamp to send
+           to the Relation Engine when looking up taxon information in
+           milliseconds since the epoch. scientific_name - the scientific
+           name of the genome. Overridden by ncbi_taxon_id. source: Source Of
+           The GFF File. Default to 'User' taxon_wsname - where the reference
            taxons are. Default to 'ReferenceTaxons' taxon_id - if defined,
            will try to link the Genome to the specified taxonomy id in lieu
            of performing the lookup during upload release: Release Or Version
@@ -163,7 +167,9 @@ class kb_uploadmethods:
            parameter "source" of String, parameter "taxon_wsname" of String,
            parameter "taxon_id" of String, parameter "release" of String,
            parameter "genetic_code" of Long, parameter "type" of String,
-           parameter "generate_missing_genes" of String
+           parameter "generate_missing_genes" of String, parameter
+           "ncbi_taxon_id" of Long, parameter "relation_engine_timestamp_ms"
+           of Long
         :returns: instance of type "UploadFastaGFFMethodResult" -> structure:
            parameter "genome_ref" of String, parameter "genome_info" of
            String, parameter "report_name" of type "report_name", parameter
@@ -471,10 +477,14 @@ class kb_uploadmethods:
            genome_name - becomes the name of the object workspace_name - the
            name of the workspace it gets saved to. source - Source of the
            file typically something like RefSeq or Ensembl optional params:
-           release - Release or version number of the data per example
-           Ensembl has numbered releases of all their data: Release 31
-           scientific_name - will be used to set the scientific name of the
-           genome and link to a taxon taxon_id - if defined, will try to link
+           ncbi_taxon_id - the numeric ID of the NCBI taxon to which this
+           genome belongs. If this is included scientific_name is ignored.
+           relation_engine_timestamp_ms - the timestamp to send to the
+           Relation Engine when looking up taxon information in milliseconds
+           since the epoch. scientific_name - the scientific name of the
+           genome. Overridden by ncbi_taxon_id. release - Release or version
+           number of the data per example Ensembl has numbered releases of
+           all their data: Release 31 taxon_id - if defined, will try to link
            the Genome to the specified taxonomy id in lieu of performing the
            lookup during upload generate_ids_if_needed - If field used for
            feature id is not there, generate ids (default behavior is raising
@@ -488,7 +498,9 @@ class kb_uploadmethods:
            of String, parameter "genetic_code" of Long, parameter "type" of
            String, parameter "scientific_name" of String, parameter
            "taxon_id" of String, parameter "generate_ids_if_needed" of
-           String, parameter "generate_missing_genes" of String
+           String, parameter "generate_missing_genes" of String, parameter
+           "ncbi_taxon_id" of Long, parameter "relation_engine_timestamp_ms"
+           of Long
         :returns: instance of type "GenomeSaveResult" -> structure: parameter
            "genome_ref" of String
         """

--- a/lib/kb_uploadmethods/kb_uploadmethodsImpl.py
+++ b/lib/kb_uploadmethods/kb_uploadmethodsImpl.py
@@ -40,7 +40,7 @@ class kb_uploadmethods:
     ######################################### noqa
     VERSION = "1.0.49"
     GIT_URL = "https://github.com/kbaseapps/kb_uploadmethods.git"
-    GIT_COMMIT_HASH = "0394ebd89ab7cf02c75db382f8022bb02583031a"
+    GIT_COMMIT_HASH = "e5b5773522c0834eeeb99fed3411617d59607c9a"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -149,17 +149,17 @@ class kb_uploadmethods:
            fasta file containing assembled contigs/chromosomes gff_file: gff
            file containing predicted gene models and corresponding features
            Optional params: scientific_name - the scientific name of the
-           genome. Overridden by NCBI taxon id. taxon_id - the numeric ID of
-           the NCBI taxon to which this genome belongs. If defined, will try
-           to link the Genome to the specified taxonomy id in lieu of
-           performing the lookup during upload source: Source Of The GFF
-           File. Default to 'User' taxon_wsname - where the reference taxons
-           are. Default to 'ReferenceTaxons' release: Release Or Version Of
-           The Source Data genetic_code: Genetic Code For The Organism type:
-           'Reference', 'User upload', 'Representative') -> structure:
-           parameter "fasta_file" of String, parameter "gff_file" of String,
-           parameter "genome_name" of String, parameter "workspace_name" of
-           type "workspace_name" (workspace name of the object), parameter
+           genome. taxon_id - the numeric ID of the NCBI taxon to which this
+           genome belongs. If defined, will try to link the Genome to the
+           specified taxonomy id in lieu of performing the lookup during
+           upload source: Source Of The GFF File. Default to 'User'
+           taxon_wsname - where the reference taxons are. Default to
+           'ReferenceTaxons' release: Release Or Version Of The Source Data
+           genetic_code: Genetic Code For The Organism type: 'Reference',
+           'User upload', 'Representative') -> structure: parameter
+           "fasta_file" of String, parameter "gff_file" of String, parameter
+           "genome_name" of String, parameter "workspace_name" of type
+           "workspace_name" (workspace name of the object), parameter
            "genome_type" of String, parameter "scientific_name" of String,
            parameter "source" of String, parameter "taxon_wsname" of String,
            parameter "taxon_id" of String, parameter "release" of String,
@@ -467,27 +467,25 @@ class kb_uploadmethods:
            genome_name - becomes the name of the object workspace_name - the
            name of the workspace it gets saved to. source - Source of the
            file typically something like RefSeq or Ensembl optional params:
-           scientific_name - the scientific name of the genome. Overridden by
-           NCBI taxon id. taxon_id - the numeric ID of the NCBI taxon to
-           which this genome belongs. If defined, will try to link the Genome
-           to the specified taxonomy id in lieu of performing the lookup
-           during upload release - Release or version number of the data per
-           example Ensembl has numbered releases of all their data: Release
-           31 taxon_id - if defined, will try to link the Genome to the
-           specified taxonomy id in lieu of performing the lookup during
-           upload generate_ids_if_needed - If field used for feature id is
-           not there, generate ids (default behavior is raising an exception)
-           generate_missing_genes - Generate gene feature for CDSs that do
-           not have a parent in file genetic_code - Genetic code of organism.
-           Overwrites determined GC from taxon object type - Reference,
-           Representative or User upload) -> structure: parameter
-           "staging_file_subdir_path" of String, parameter "genome_name" of
-           String, parameter "workspace_name" of String, parameter "source"
-           of String, parameter "genome_type" of String, parameter "release"
-           of String, parameter "genetic_code" of Long, parameter "type" of
-           String, parameter "scientific_name" of String, parameter
-           "taxon_id" of String, parameter "generate_ids_if_needed" of
-           String, parameter "generate_missing_genes" of String
+           scientific_name - the scientific name of the genome. taxon_id -
+           the numeric ID of the NCBI taxon to which this genome belongs. If
+           defined, will try to link the Genome to the specified taxonomy id
+           in lieu of performing the lookup during upload release - Release
+           or version number of the data per example Ensembl has numbered
+           releases of all their data: Release 31 generate_ids_if_needed - If
+           field used for feature id is not there, generate ids (default
+           behavior is raising an exception) generate_missing_genes -
+           Generate gene feature for CDSs that do not have a parent in file
+           genetic_code - Genetic code of organism. Overwrites determined GC
+           from taxon object type - Reference, Representative or User upload)
+           -> structure: parameter "staging_file_subdir_path" of String,
+           parameter "genome_name" of String, parameter "workspace_name" of
+           String, parameter "source" of String, parameter "genome_type" of
+           String, parameter "release" of String, parameter "genetic_code" of
+           Long, parameter "type" of String, parameter "scientific_name" of
+           String, parameter "taxon_id" of String, parameter
+           "generate_ids_if_needed" of String, parameter
+           "generate_missing_genes" of String
         :returns: instance of type "GenomeSaveResult" -> structure: parameter
            "genome_ref" of String
         """

--- a/lib/kb_uploadmethods/kb_uploadmethodsImpl.py
+++ b/lib/kb_uploadmethods/kb_uploadmethodsImpl.py
@@ -176,6 +176,11 @@ class kb_uploadmethods:
         print('--->\nRunning uploadmethods.upload_fasta_gff_file\nparams:')
         print((json.dumps(params, indent=1)))
 
+        if params.get('ncbi_taxon_id'):
+            params['taxon_id'] = params['ncbi_taxon_id']
+        if params.get('relation_engine_timestamp_ms'):
+            params['time_stamp'] = params['relation_engine_timestamp_ms']
+
         for key in list(params.keys()):
             value = params[key]
             if value is None:
@@ -490,6 +495,12 @@ class kb_uploadmethods:
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN import_genbank_from_staging
+
+        if params.get('ncbi_taxon_id'):
+            params['taxon_id'] = params['ncbi_taxon_id']
+        if params.get('relation_engine_timestamp_ms'):
+            params['time_stamp'] = params['relation_engine_timestamp_ms']
+
         for key, value in list(params.items()):
             if isinstance(value, str):
                 params[key] = value.strip()

--- a/lib/kb_uploadmethods/kb_uploadmethodsImpl.py
+++ b/lib/kb_uploadmethods/kb_uploadmethodsImpl.py
@@ -38,9 +38,9 @@ class kb_uploadmethods:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "1.0.48"
+    VERSION = "1.0.49"
     GIT_URL = "https://github.com/kbaseapps/kb_uploadmethods.git"
-    GIT_COMMIT_HASH = "6b3b13149c785420a98c7e3c196e4528070b24f3"
+    GIT_COMMIT_HASH = "0394ebd89ab7cf02c75db382f8022bb02583031a"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -148,18 +148,15 @@ class kb_uploadmethods:
            workspace name/ID of the object For staging area: fasta_file:
            fasta file containing assembled contigs/chromosomes gff_file: gff
            file containing predicted gene models and corresponding features
-           Optional params: ncbi_taxon_id - the numeric ID of the NCBI taxon
-           to which this genome belongs. If this is included scientific_name
-           is ignored. relation_engine_timestamp_ms - the timestamp to send
-           to the Relation Engine when looking up taxon information in
-           milliseconds since the epoch. scientific_name - the scientific
-           name of the genome. Overridden by ncbi_taxon_id. source: Source Of
-           The GFF File. Default to 'User' taxon_wsname - where the reference
-           taxons are. Default to 'ReferenceTaxons' taxon_id - if defined,
-           will try to link the Genome to the specified taxonomy id in lieu
-           of performing the lookup during upload release: Release Or Version
-           Of The Source Data genetic_code: Genetic Code For The Organism
-           type: 'Reference', 'User upload', 'Representative') -> structure:
+           Optional params: scientific_name - the scientific name of the
+           genome. Overridden by NCBI taxon id. taxon_id - the numeric ID of
+           the NCBI taxon to which this genome belongs. If defined, will try
+           to link the Genome to the specified taxonomy id in lieu of
+           performing the lookup during upload source: Source Of The GFF
+           File. Default to 'User' taxon_wsname - where the reference taxons
+           are. Default to 'ReferenceTaxons' release: Release Or Version Of
+           The Source Data genetic_code: Genetic Code For The Organism type:
+           'Reference', 'User upload', 'Representative') -> structure:
            parameter "fasta_file" of String, parameter "gff_file" of String,
            parameter "genome_name" of String, parameter "workspace_name" of
            type "workspace_name" (workspace name of the object), parameter
@@ -167,9 +164,7 @@ class kb_uploadmethods:
            parameter "source" of String, parameter "taxon_wsname" of String,
            parameter "taxon_id" of String, parameter "release" of String,
            parameter "genetic_code" of Long, parameter "type" of String,
-           parameter "generate_missing_genes" of String, parameter
-           "ncbi_taxon_id" of Long, parameter "relation_engine_timestamp_ms"
-           of Long
+           parameter "generate_missing_genes" of String
         :returns: instance of type "UploadFastaGFFMethodResult" -> structure:
            parameter "genome_ref" of String, parameter "genome_info" of
            String, parameter "report_name" of type "report_name", parameter
@@ -181,11 +176,6 @@ class kb_uploadmethods:
 
         print('--->\nRunning uploadmethods.upload_fasta_gff_file\nparams:')
         print((json.dumps(params, indent=1)))
-
-        if params.get('ncbi_taxon_id'):
-            params['taxon_id'] = params['ncbi_taxon_id']
-        if params.get('relation_engine_timestamp_ms'):
-            params['time_stamp'] = params['relation_engine_timestamp_ms']
 
         for key in list(params.keys()):
             value = params[key]
@@ -477,41 +467,33 @@ class kb_uploadmethods:
            genome_name - becomes the name of the object workspace_name - the
            name of the workspace it gets saved to. source - Source of the
            file typically something like RefSeq or Ensembl optional params:
-           ncbi_taxon_id - the numeric ID of the NCBI taxon to which this
-           genome belongs. If this is included scientific_name is ignored.
-           relation_engine_timestamp_ms - the timestamp to send to the
-           Relation Engine when looking up taxon information in milliseconds
-           since the epoch. scientific_name - the scientific name of the
-           genome. Overridden by ncbi_taxon_id. release - Release or version
-           number of the data per example Ensembl has numbered releases of
-           all their data: Release 31 taxon_id - if defined, will try to link
-           the Genome to the specified taxonomy id in lieu of performing the
-           lookup during upload generate_ids_if_needed - If field used for
-           feature id is not there, generate ids (default behavior is raising
-           an exception) generate_missing_genes - Generate gene feature for
-           CDSs that do not have a parent in file genetic_code - Genetic code
-           of organism. Overwrites determined GC from taxon object type -
-           Reference, Representative or User upload) -> structure: parameter
+           scientific_name - the scientific name of the genome. Overridden by
+           NCBI taxon id. taxon_id - the numeric ID of the NCBI taxon to
+           which this genome belongs. If defined, will try to link the Genome
+           to the specified taxonomy id in lieu of performing the lookup
+           during upload release - Release or version number of the data per
+           example Ensembl has numbered releases of all their data: Release
+           31 taxon_id - if defined, will try to link the Genome to the
+           specified taxonomy id in lieu of performing the lookup during
+           upload generate_ids_if_needed - If field used for feature id is
+           not there, generate ids (default behavior is raising an exception)
+           generate_missing_genes - Generate gene feature for CDSs that do
+           not have a parent in file genetic_code - Genetic code of organism.
+           Overwrites determined GC from taxon object type - Reference,
+           Representative or User upload) -> structure: parameter
            "staging_file_subdir_path" of String, parameter "genome_name" of
            String, parameter "workspace_name" of String, parameter "source"
            of String, parameter "genome_type" of String, parameter "release"
            of String, parameter "genetic_code" of Long, parameter "type" of
            String, parameter "scientific_name" of String, parameter
            "taxon_id" of String, parameter "generate_ids_if_needed" of
-           String, parameter "generate_missing_genes" of String, parameter
-           "ncbi_taxon_id" of Long, parameter "relation_engine_timestamp_ms"
-           of Long
+           String, parameter "generate_missing_genes" of String
         :returns: instance of type "GenomeSaveResult" -> structure: parameter
            "genome_ref" of String
         """
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN import_genbank_from_staging
-
-        if params.get('ncbi_taxon_id'):
-            params['taxon_id'] = params['ncbi_taxon_id']
-        if params.get('relation_engine_timestamp_ms'):
-            params['time_stamp'] = params['relation_engine_timestamp_ms']
 
         for key, value in list(params.items()):
             if isinstance(value, str):

--- a/test/genbank_importer_test.py
+++ b/test/genbank_importer_test.py
@@ -150,16 +150,12 @@ class kb_uploadmethodsTest(unittest.TestCase):
         params = {
           'staging_file_subdir_path': gbk_path,
           'genome_name': ws_obj_name,
-          'ncbi_taxon_id': '28077',
-          'relation_engine_timestamp_ms': 1625695904755,
+          'taxon_id': '28077',
           'workspace_name': self.getWsName(),
           'source': 'RefSeq'
         }
 
         ref = self.getImpl().import_genbank_from_staging(self.getContext(), params)
-
-        self.assertEqual(params['taxon_id'], params['ncbi_taxon_id'])
-        self.assertEqual(params['time_stamp'], params['relation_engine_timestamp_ms'])
 
         self.assertTrue('genome_ref' in ref[0])
         self.assertTrue('genome_info' in ref[0])

--- a/test/gff_fasta_plant_importer_test.py
+++ b/test/gff_fasta_plant_importer_test.py
@@ -145,8 +145,7 @@ class kb_uploadmethodsTest(unittest.TestCase):
             "workspace_name": self.getWsName(),
             "genome_name": ws_obj_name,
             "scientific_name": scientific_name,
-            "ncbi_taxon_id": "28077",
-            "relation_engine_timestamp_ms": 1625695904755,
+            "taxon_id": "28077",
             "genetic_code": None,
             "source": None,
             "taxon_wsname": None,
@@ -155,9 +154,6 @@ class kb_uploadmethodsTest(unittest.TestCase):
         }
 
         ref = self.getImpl().upload_fasta_gff_file(self.getContext(), params)
-
-        self.assertEqual(params['taxon_id'], params['ncbi_taxon_id'])
-        self.assertEqual(params['time_stamp'], params['relation_engine_timestamp_ms'])
 
         self.assertTrue('genome_ref' in ref[0])
         self.assertTrue('genome_info' in ref[0])

--- a/test/gff_fasta_plant_importer_test.py
+++ b/test/gff_fasta_plant_importer_test.py
@@ -133,10 +133,11 @@ class kb_uploadmethodsTest(unittest.TestCase):
     @patch.object(UploaderUtil, "update_staging_service", return_value=None)
     def test_upload_fasta_gff_file(self, download_staging_file, update_staging_service):
 
-        fasta_file = "Test_v1.0.fa.gz"
-        gff_file = "Test_v1.0.gene.gff3.gz"
+        fasta_file = 'Test_v1.0.fa.gz'
+        gff_file = 'Test_v1.0.gene.gff3.gz'
         ws_obj_name = 'MyGenome'
-        scientific_name = "Populus trichocarpa"
+        scientific_name = 'Populus trichocarpa'
+        expected_scientific_name = 'Nitrospirillum amazonense'
 
         params = {
             "fasta_file": fasta_file,
@@ -144,6 +145,8 @@ class kb_uploadmethodsTest(unittest.TestCase):
             "workspace_name": self.getWsName(),
             "genome_name": ws_obj_name,
             "scientific_name": scientific_name,
+            "ncbi_taxon_id": "28077",
+            "relation_engine_timestamp_ms": 1625695904755,
             "genetic_code": None,
             "source": None,
             "taxon_wsname": None,
@@ -153,18 +156,22 @@ class kb_uploadmethodsTest(unittest.TestCase):
 
         ref = self.getImpl().upload_fasta_gff_file(self.getContext(), params)
 
+        self.assertEqual(params['taxon_id'], params['ncbi_taxon_id'])
+        self.assertEqual(params['time_stamp'], params['relation_engine_timestamp_ms'])
+
         self.assertTrue('genome_ref' in ref[0])
         self.assertTrue('genome_info' in ref[0])
         self.assertTrue('report_ref' in ref[0])
         self.assertTrue('report_name' in ref[0])
 
         genome_info = ref[0]['genome_info']
-        self.assertEqual(genome_info[10]['Domain'], 'Unknown')
+        self.assertEqual(genome_info[10]['Domain'], 'Bacteria')
         self.assertEqual(genome_info[10]['Genetic code'], '11')
-        self.assertEqual(genome_info[10]['Name'], 'Populus trichocarpa')
+        self.assertEqual(genome_info[10]['Name'], expected_scientific_name)
         self.assertEqual(genome_info[10]['Source'], 'User')
         self.assertTrue('GC content' in genome_info[10])
         self.assertTrue(re.match("^\d+?\.\d+?$", genome_info[10]['GC content']) is not None)
         self.assertTrue('Size' in genome_info[10])
         self.assertTrue(genome_info[10]['Size'].isdigit())
-        self.assertEqual(genome_info[10]['Taxonomy'], 'Unconfirmed Organism')
+        self.assertIn('Bacteria', genome_info[10]['Taxonomy'])
+        self.assertIn('Nitrospirillum', genome_info[10]['Taxonomy'])

--- a/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
@@ -200,11 +200,7 @@
         },
         {
           "input_parameter": "scientific_name",
-          "target_property": "ncbi_taxon_id"
-        },
-        {
-          "narrative_system_variable": "timestamp_epoch_ms",
-          "target_property": "relation_engine_timestamp_ms"
+          "target_property": "taxon_id"
         },
         {
           "input_parameter": "generate_ids_if_needed",

--- a/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
@@ -115,7 +115,7 @@
     },
     {
       "id" : "scientific_name",
-      "optional" : false,
+      "optional" : true,
       "advanced" : false,
       "allow_multiple" : false,
       "default_values" : [ "" ],

--- a/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
@@ -1,6 +1,6 @@
 {
   "ver" : "",
-  "authors" : ["tgu2"],
+  "authors" : ["tgu2", "qzhang"],
   "contact" : "http://kbase.us/contact-us/",
   "visible" : true,
   "categories" : [ "inactive","assembly","upload" ],
@@ -115,21 +115,29 @@
     },
     {
       "id" : "scientific_name",
-      "optional" : true,
-      "advanced" : true,
+      "optional" : false,
+      "advanced" : false,
       "allow_multiple" : false,
       "default_values" : [ "" ],
-      "field_type" : "text",
-      "text_options" : {}
-    },
-    {
-      "id" : "taxon_id",
-      "optional" : true,
-      "advanced" : true,
-      "allow_multiple" : false,
-      "default_values" : [ "" ],
-      "field_type" : "text",
-      "text_options" : {}
+      "field_type" : "dynamic_dropdown",
+      "dynamic_dropdown_options": {
+          "data_source": "custom",
+          "service_function": "taxonomy_re_api.search_species",
+          "service_version": "dev",
+          "service_params": [
+              {
+                  "search_text": "prefix:{{dynamic_dropdown_input}}",
+                  "ns": "ncbi_taxonomy",
+                  "limit": 20
+              }
+          ],
+          "query_on_empty_input": 0,
+          "result_array_index": 0,
+          "path_to_selection_items": ["results"],
+          "selection_id": "ncbi_taxon_id",
+          "description_template": "NCBI Tax ID {{ncbi_taxon_id}}:&nbsp<strong>{{scientific_name}}</strong>",
+          "multiselection": false
+      }
     },
     {
       "id": "generate_ids_if_needed",
@@ -193,10 +201,6 @@
         {
           "input_parameter": "scientific_name",
           "target_property": "scientific_name"
-        },
-        {
-          "input_parameter": "taxon_id",
-          "target_property": "taxon_id"
         },
         {
           "input_parameter": "generate_ids_if_needed",

--- a/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
@@ -200,7 +200,11 @@
         },
         {
           "input_parameter": "scientific_name",
-          "target_property": "scientific_name"
+          "target_property": "ncbi_taxon_id"
+        },
+        {
+          "narrative_system_variable": "timestamp_epoch_ms",
+          "target_property": "relation_engine_timestamp_ms"
         },
         {
           "input_parameter": "generate_ids_if_needed",

--- a/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/spec.json
@@ -221,7 +221,11 @@
         },
         {
           "input_parameter": "scientific_name",
-          "target_property": "scientific_name"
+          "target_property": "ncbi_taxon_id"
+        },
+        {
+          "narrative_system_variable": "timestamp_epoch_ms",
+          "target_property": "relation_engine_timestamp_ms"
         },
         {
           "input_parameter": "source",

--- a/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/spec.json
@@ -1,6 +1,6 @@
 {
   "ver" : "1.0.0",
-  "authors" : ["seaver","tgu2"],
+  "authors" : ["seaver", "tgu2", "qzhang"],
   "contact" : "http://kbase.us/contact-us/",
   "visble" : true,
   "categories" : [ "inactive","assembly","upload" ],
@@ -98,12 +98,29 @@
     },
     {
       "id" : "scientific_name",
-      "optional" : true,
+      "optional" : false,
       "advanced" : false,
       "allow_multiple" : false,
-      "default_values" : [ "unknown_taxon" ],
-      "field_type" : "text",
-      "text_options" : {}
+      "default_values" : [ "" ],
+      "field_type" : "dynamic_dropdown",
+      "dynamic_dropdown_options": {
+          "data_source": "custom",
+          "service_function": "taxonomy_re_api.search_species",
+          "service_version": "dev",
+          "service_params": [
+              {
+                  "search_text": "prefix:{{dynamic_dropdown_input}}",
+                  "ns": "ncbi_taxonomy",
+                  "limit": 20
+              }
+          ],
+          "query_on_empty_input": 0,
+          "result_array_index": 0,
+          "path_to_selection_items": ["results"],
+          "selection_id": "ncbi_taxon_id",
+          "description_template": "NCBI Tax ID {{ncbi_taxon_id}}:&nbsp<strong>{{scientific_name}}</strong>",
+          "multiselection": false
+      }
     },
     {
       "id" : "source",
@@ -134,15 +151,6 @@
     },
     {
       "id" : "taxon_wsname",
-      "optional" : true,
-      "advanced" : true,
-      "allow_multiple" : false,
-      "default_values" : [ "" ],
-      "field_type" : "text",
-      "text_options" : {}
-    },
-    {
-      "id" : "taxon_id",
       "optional" : true,
       "advanced" : true,
       "allow_multiple" : false,
@@ -222,10 +230,6 @@
         {
           "input_parameter": "taxon_wsname",
           "target_property": "taxon_wsname"
-        },
-        {
-          "input_parameter": "taxon_id",
-          "target_property": "taxon_id"
         },
         {
           "input_parameter": "release",

--- a/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/spec.json
@@ -98,7 +98,7 @@
     },
     {
       "id" : "scientific_name",
-      "optional" : false,
+      "optional" : true,
       "advanced" : false,
       "allow_multiple" : false,
       "default_values" : [ "" ],

--- a/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/spec.json
@@ -221,11 +221,7 @@
         },
         {
           "input_parameter": "scientific_name",
-          "target_property": "ncbi_taxon_id"
-        },
-        {
-          "narrative_system_variable": "timestamp_epoch_ms",
-          "target_property": "relation_engine_timestamp_ms"
+          "target_property": "taxon_id"
         },
         {
           "input_parameter": "source",


### PR DESCRIPTION
…gff_fasta_as_genome_from_staging to accept ncbi_taxon_id and timestamp inputs

# Modified UI spec of import_genbank_as_genome_from_staging and import_gff_fasta_as_genome_from_staging to accept ncbi_taxon_id and timestamp inputs

-   The UI changes are needed in kb_uploadmethods such that the 'scientific_name' input will fetch from the dynamic dropdown the data for both params['ncbi_taxon_id'] and parms['relation_engine_timestamp_ms']. 
-   Removed the taxon_id UI input because it will be overwritten by the 'ncbi_taxon_id'.
-   Added code to assign params['ncbi_taxon_id'] to params['taxon_id'] and parms['relation_engine_timestamp_ms'] to params['time_stamp'] in order to pass them to GFU.
-   List any dependencies that are required for this change.

# Jira Ticket / Issue
-  https://kbase-jira.atlassian.net/browse/PUBLIC-1667

# Summary: 
What I am trying to do is to ensure the 'scientific_name' is correctly fetched for a given genome input file after the uploading.

Previously there are, in the UI, 'scientific_name' and 'taxon_id' both optional and editable textboxes. So if the user types in a scientific_name, the 'scientific_name' will be overwritten by GFU when a 'taxon_id' is given. If a 'taxon_id' is not given, GFU will 'set_default_taxon_data'. Either way, there maybe chance the 'scientific_name' ended up with not something the user expected--that's why we have the jira ticket.

Now I removed the 'taxon_id' input box. Instead, by implementing the dynamic dropdown for the 'scientific_name' input to let the use select an NCBI taxon_id (i.e., params['ncbi_taxon_id']) associated with the typed in 'scientific_name'. This way, we can avoid the occurrence of conflict 'scientific_name'.