### PR TITLE
DATAUP-562: Require at least 1 file for reads uploaders

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 ###Release Notes
 
+**1.0.50**
+Require at least one input file for SRA and non/interleaved reads
+
 **1.0.49**
 Add dynamic dropdown boxes for scientific_name ui input to address conflicting scientific_name/taxon_id issues. The dynamic dropdown will connect to the re_api_search service to match the ncbi_taxon_id for the scientific_name user types into the input box.
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.49
+    1.0.50
 
 owners:
     [tgu2, slebras, gaprice, qzhang]

--- a/ui/narrative/methods/import_fastq_interleaved_as_reads_from_staging/spec.json
+++ b/ui/narrative/methods/import_fastq_interleaved_as_reads_from_staging/spec.json
@@ -17,7 +17,7 @@
   "parameters": [
     {
       "id": "fastq_fwd_staging_file_name",
-      "optional": true,
+      "optional": false,
       "advanced": false,
       "allow_multiple": false,
       "default_values": [

--- a/ui/narrative/methods/import_fastq_noninterleaved_as_reads_from_staging/spec.json
+++ b/ui/narrative/methods/import_fastq_noninterleaved_as_reads_from_staging/spec.json
@@ -17,7 +17,7 @@
   "parameters": [
     {
       "id": "fastq_fwd_staging_file_name",
-      "optional": true,
+      "optional": false,
       "advanced": false,
       "allow_multiple": false,
       "default_values": [

--- a/ui/narrative/methods/import_sra_as_reads_from_staging/spec.json
+++ b/ui/narrative/methods/import_sra_as_reads_from_staging/spec.json
@@ -19,7 +19,7 @@
   "parameters": [
     {
       "id": "sra_staging_file_name",
-      "optional": true,
+      "optional": false,
       "advanced": false,
       "allow_multiple": false,
       "default_values": [


### PR DESCRIPTION
# Description of PR purpose/changes

The 3 individual reads loaders (SRA, interleaved, non-interleaved) don't require any files at all in the UI spec, an error.

# Jira Ticket / Issue

e.g. <https://kbase-jira.atlassian.net/browse/DATAUP-X>

-   [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions

-   Details for how to test the PR: 
-   [x] Tests pass in Travis-CI and locally 

# Dev Checklist:

-   [x] My code follows the guidelines at <https://sites.google.com/truss.works/kbasetruss/development>
-   [x] I have performed a self-review of my own code
-   [n/a] I have commented my code, particularly in hard-to-understand areas
-   [n/a] I have made corresponding changes to the documentation, including updating the README with app information changes
-   [x] My changes generate no new warnings
-   [n/a] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing tests pass locally with my changes
-   [n/a] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

-   [x] [Version has been bumped](https://semver.org/) in `kbase.yml`
-   [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
