### PR TITLE
Add valid_ws_types to sra and interleaved reads

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 ###Release Notes
 
 **1.0.50**
-Require at least one input file for SRA and non/interleaved reads
+Require at least one input file for SRA and non/interleaved reads, set valid_ws_types where missing
 
 **1.0.49**
 Add dynamic dropdown boxes for scientific_name ui input to address conflicting scientific_name/taxon_id issues. The dynamic dropdown will connect to the re_api_search service to match the ncbi_taxon_id for the scientific_name user types into the input box.

--- a/ui/narrative/methods/import_fastq_interleaved_as_reads_from_staging/spec.json
+++ b/ui/narrative/methods/import_fastq_interleaved_as_reads_from_staging/spec.json
@@ -76,6 +76,10 @@
       ],
       "field_type": "text",
       "text_options": {
+        "valid_ws_types": [
+          "KBaseFile.SingleEndLibrary",
+          "KBaseFile.PairedEndLibrary"
+        ],
         "is_output_name": true
       }
     },

--- a/ui/narrative/methods/import_sra_as_reads_from_staging/spec.json
+++ b/ui/narrative/methods/import_sra_as_reads_from_staging/spec.json
@@ -78,6 +78,10 @@
       ],
       "field_type": "text",
       "text_options": {
+        "valid_ws_types": [
+          "KBaseFile.SingleEndLibrary",
+          "KBaseFile.PairedEndLibrary"
+        ],
         "is_output_name": true
       }
     },


### PR DESCRIPTION
# Description of PR purpose/changes

Add missing ws type spec for sra and interleaved reads apps

No version bump as 1.0.50 hasn't been released yet

non-interleaved reads already has types specified

# Jira Ticket / Issue

e.g. <https://kbase-jira.atlassian.net/browse/DATAUP-X>

-   [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions

-   Details for how to test the PR: 
-   [x] Tests pass in Travis-CI and locally 

# Dev Checklist:

-   [x] My code follows the guidelines at <https://sites.google.com/truss.works/kbasetruss/development>
-   [x] I have performed a self-review of my own code
-   [n/a] I have commented my code, particularly in hard-to-understand areas
-   [n/a] I have made corresponding changes to the documentation, including updating the README with app information changes
-   [n/a] My changes generate no new warnings
-   [n/a] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing tests pass locally with my changes
-   [n/a] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

-   [n/a] [Version has been bumped](https://semver.org/) in `kbase.yml`
-   [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
