### PR TITLE
SCT-3032 directly upload staging file

### DIFF
--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -1,7 +1,15 @@
 name: KBase SDK Tests
 
 on:
-  [push, pull_request]
+  push:
+    branches:
+    - master
+    - main
+  pull_request:
+    branches:
+    - master
+    - main
+    - develop
 
 jobs:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 ###Release Notes
 
+**1.0.52**
+Directly copy files in the scratch folder to staging image. Instead of using staging API.
+
 **1.0.51**
 Set valid_ws_types for SRA and interleaved reads import apps
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.51
+    1.0.52
 
 owners:
     [tgu2, slebras, gaprice, qzhang]

--- a/lib/kb_uploadmethods/Utils/UnpackFileUtil.py
+++ b/lib/kb_uploadmethods/Utils/UnpackFileUtil.py
@@ -193,9 +193,6 @@ class UnpackFileUtil:
         log("Unpacked files:\n  {}".format(
                           '\n  '.join(unpacked_file_path_list)))
 
-        # self._file_to_staging(unpacked_file_path_list, os.path.dirname(
-        #                                         params.get('staging_file_subdir_path')))
-
         self._file_to_staging_direct(unpacked_file_path_list, os.path.dirname(
                                                 params.get('staging_file_subdir_path')))
 
@@ -234,7 +231,6 @@ class UnpackFileUtil:
         log("Unpacked files:\n  {}".format(
                           '\n  '.join(unpacked_file_path_list)))
 
-        # self._file_to_staging(unpacked_file_path_list)
         self._file_to_staging_direct(unpacked_file_path_list)
 
         unpacked_file_path = ','.join(unpacked_file_path_list)

--- a/lib/kb_uploadmethods/Utils/UnpackFileUtil.py
+++ b/lib/kb_uploadmethods/Utils/UnpackFileUtil.py
@@ -20,6 +20,27 @@ def log(message, prefix_newline=False):
 
 class UnpackFileUtil:
 
+    # staging file prefix
+    STAGING_GLOBAL_FILE_PREFIX = '/data/bulk/'
+    STAGING_USER_FILE_PREFIX = '/staging/'
+
+    def _get_staging_file_path(self, token_user, staging_file_subdir_path=''):
+        """
+        _get_staging_file_path: return staging area file path
+
+        directory pattern:
+            perfered to return user specific path: /staging/sub_dir/file_name
+            if this path is not visible to user, use global bulk path: /data/bulk/user_name/sub_dir/file_name
+        """
+
+        user_path = os.path.join(self.STAGING_USER_FILE_PREFIX, staging_file_subdir_path.strip('/'))
+
+        if os.path.exists(user_path):
+            return user_path
+        else:
+            return os.path.join(self.STAGING_GLOBAL_FILE_PREFIX, token_user,
+                                staging_file_subdir_path.strip('/'))
+
     def _staging_service_host(self):
 
         deployment_path = os.environ["KB_DEPLOYMENT_CONFIG"]
@@ -31,6 +52,15 @@ class UnpackFileUtil:
         staging_service_host = endpoint + '/staging_service'
 
         return staging_service_host
+
+    def _file_to_staging_direct(self, file_path_list, subdir_folder=''):
+
+        staging_dir = self._get_staging_file_path(self.user_id, subdir_folder)
+
+        for file_path in file_path_list:
+            shutil.copy2(file_path, staging_dir)
+            log('Copied file from %s to %s' %
+                (file_path, staging_dir))
 
     def _file_to_staging(self, file_path_list, subdir_folder=None):
         """
@@ -163,7 +193,10 @@ class UnpackFileUtil:
         log("Unpacked files:\n  {}".format(
                           '\n  '.join(unpacked_file_path_list)))
 
-        self._file_to_staging(unpacked_file_path_list, os.path.dirname(
+        # self._file_to_staging(unpacked_file_path_list, os.path.dirname(
+        #                                         params.get('staging_file_subdir_path')))
+
+        self._file_to_staging_direct(unpacked_file_path_list, os.path.dirname(
                                                 params.get('staging_file_subdir_path')))
 
         unpacked_file_path = ','.join(unpacked_file_path_list)
@@ -201,7 +234,9 @@ class UnpackFileUtil:
         log("Unpacked files:\n  {}".format(
                           '\n  '.join(unpacked_file_path_list)))
 
-        self._file_to_staging(unpacked_file_path_list)
+        # self._file_to_staging(unpacked_file_path_list)
+        self._file_to_staging_direct(unpacked_file_path_list)
+
         unpacked_file_path = ','.join(unpacked_file_path_list)
         returnVal = {'unpacked_file_path': unpacked_file_path}
 

--- a/lib/kb_uploadmethods/Utils/UnpackFileUtil.py
+++ b/lib/kb_uploadmethods/Utils/UnpackFileUtil.py
@@ -28,8 +28,8 @@ class UnpackFileUtil:
         """
         _get_staging_file_path: return staging area file path
 
-        directory pattern:
-            perfered to return user specific path: /staging/sub_dir/file_name
+        return:
+            preferred to return user specific path: /staging/sub_dir/file_name
             if this path is not visible to user, use global bulk path: /data/bulk/user_name/sub_dir/file_name
         """
 

--- a/test/unpack_staging_and_web_file_test.py
+++ b/test/unpack_staging_and_web_file_test.py
@@ -117,6 +117,10 @@ class kb_uploadmethodsTest(unittest.TestCase):
         print('Mocking _file_to_staging')
         print("Mocking uploaded files to staging area:\n{}".format('\n'.join(file_path_list)))
 
+    def mock_file_to_staging_direct(file_path_list, subdir_folder=''):
+        print('Mocking _file_to_staging_direct')
+        print("Mocking uploaded files to staging area:\n{}".format('\n'.join(file_path_list)))
+
     def mock_download_staging_file(params):
         print('Mocking DataFileUtilClient.download_staging_file')
         print(params)
@@ -127,8 +131,8 @@ class kb_uploadmethodsTest(unittest.TestCase):
 
         return {'copy_file_path': fq_path}
 
-    @patch.object(UnpackFileUtil, "_file_to_staging", side_effect=mock_file_to_staging)
-    def test_unpack_web_file_direct_download_trailing_space(self, _file_to_staging):
+    @patch.object(UnpackFileUtil, "_file_to_staging_direct", side_effect=mock_file_to_staging_direct)
+    def test_unpack_web_file_direct_download_trailing_space(self, _file_to_staging_direct):
         file_url = 'https://anl.box.com/shared/static/'
         file_url += 'g0064wasgaoi3sax4os06paoyxay4l3r.zip   '
 
@@ -148,8 +152,8 @@ class kb_uploadmethodsTest(unittest.TestCase):
                                 os.path.basename(file_path),
                                 'file[1-6]\.txt')
 
-    @patch.object(UnpackFileUtil, "_file_to_staging", side_effect=mock_file_to_staging)
-    def test_unpack_web_file_direct_download_multiple_urls(self, _file_to_staging):
+    @patch.object(UnpackFileUtil, "_file_to_staging_direct", side_effect=mock_file_to_staging_direct)
+    def test_unpack_web_file_direct_download_multiple_urls(self, _file_to_staging_direct):
         file_url = '  https://anl.box.com/shared/static/'
         file_url += 'g0064wasgaoi3sax4os06paoyxay4l3r.zip'
         params = {
@@ -175,8 +179,8 @@ class kb_uploadmethodsTest(unittest.TestCase):
                             os.path.basename(file_path),
                             'file[1-6]\.txt')
 
-    @patch.object(UnpackFileUtil, "_file_to_staging", side_effect=mock_file_to_staging)
-    def test_unpack_web_file_dropbox(self, _file_to_staging):
+    @patch.object(UnpackFileUtil, "_file_to_staging_direct", side_effect=mock_file_to_staging_direct)
+    def test_unpack_web_file_dropbox(self, _file_to_staging_direct):
         params = {
             'download_type': 'DropBox',
             'file_url': 'https://www.dropbox.com/s/cbiywh2aihjxdf5/Archive.zip?dl=0',
@@ -193,8 +197,8 @@ class kb_uploadmethodsTest(unittest.TestCase):
                                 os.path.basename(file_path),
                                 'file[1-6]\.txt')
 
-    @patch.object(UnpackFileUtil, "_file_to_staging", side_effect=mock_file_to_staging)
-    def test_unpack_web_file_ftp(self, _file_to_staging):
+    @patch.object(UnpackFileUtil, "_file_to_staging_direct", side_effect=mock_file_to_staging_direct)
+    def test_unpack_web_file_ftp(self, _file_to_staging_direct):
         # copy test file to FTP
         fq_filename = "Archive.zip"
         with ftplib.FTP(self.ftp_domain) as ftp_connection:
@@ -219,8 +223,8 @@ class kb_uploadmethodsTest(unittest.TestCase):
                         os.path.basename(file_path),
                         'file[1-6]\.txt')
 
-    @patch.object(UnpackFileUtil, "_file_to_staging", side_effect=mock_file_to_staging)
-    def test_unpack_web_file_google_drive(self, _file_to_staging):
+    @patch.object(UnpackFileUtil, "_file_to_staging_direct", side_effect=mock_file_to_staging_direct)
+    def test_unpack_web_file_google_drive(self, _file_to_staging_direct):
         file_url = 'https://drive.google.com/open?id=0B0exSa7ebQ0qSlJiWEVWYU5rYWM'
         params = {
             'download_type': 'Google Drive',

--- a/test/unpack_staging_and_web_file_test.py
+++ b/test/unpack_staging_and_web_file_test.py
@@ -243,8 +243,8 @@ class kb_uploadmethodsTest(unittest.TestCase):
                             'file[1-6]\.txt')
 
     @patch.object(DataFileUtil, "download_staging_file", side_effect=mock_download_staging_file)
-    @patch.object(UnpackFileUtil, "_file_to_staging", side_effect=mock_file_to_staging)
-    def test_unpack_staging_file(self, _file_to_staging, download_staging_file):
+    @patch.object(UnpackFileUtil, "_file_to_staging_direct", side_effect=mock_file_to_staging_direct)
+    def test_unpack_staging_file(self, _file_to_staging_direct, download_staging_file):
         params = {
           'staging_file_subdir_path': 'Archive.zip',
           'workspace_name': self.getWsName()


### PR DESCRIPTION
# Description of PR purpose/changes

-   Directly copy files in the scratch folder to staging image. Instead of using staging API. 

# Jira Ticket / Issue
https://kbase-jira.atlassian.net/browse/SCT-3032
https://kbase-jira.atlassian.net/browse/PTV-1695

-   [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions

-   Details for how to test the PR: 
-   [X] Tests pass in Travis-CI and locally 

# Dev Checklist:

-   [x] My code follows the guidelines at <https://sites.google.com/truss.works/kbasetruss/development>
-   [X] I have performed a self-review of my own code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation, including updating the README with app information changes
-   [ ] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

-   [x] [Version has been bumped](https://semver.org/) in `kbase.yml`
-   [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
