### PR TITLE
DATAUP-742: Add exact_match_on field to Genbank uploader

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 ###Release Notes
 
+**1.0.54**
+Add `exact_match_on` field to the Genbank uploader.
+
 **1.0.53**
 Change casing of the `ui-name` field to sentence case for importers used by the Bulk Import cell.
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.53
+    1.0.54
 
 owners:
     [tgu2, slebras, gaprice, qzhang]

--- a/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
+++ b/ui/narrative/methods/import_genbank_as_genome_from_staging/spec.json
@@ -135,6 +135,7 @@
           "result_array_index": 0,
           "path_to_selection_items": ["results"],
           "selection_id": "ncbi_taxon_id",
+          "exact_match_on": "scientific_name",
           "description_template": "NCBI Tax ID {{ncbi_taxon_id}}:&nbsp<strong>{{scientific_name}}</strong>",
           "multiselection": false
       }


### PR DESCRIPTION
# Description of PR purpose/changes

Added the `exact_match_on` field to the Genbank dynamic dropdown config. This will be used in the xSV bulk import to match the user input in the xSV file to the response from the taxon API.

# Jira Ticket / Issue

e.g. <https://kbase-jira.atlassian.net/browse/DATAUP-X>

-   [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions

-   Details for how to test the PR: 
-   [X] Tests pass in Travis-CI and locally 

# Dev Checklist:

-   [X] My code follows the guidelines at <https://sites.google.com/truss.works/kbasetruss/development>
-   [X] I have performed a self-review of my own code
-   [n/a] I have commented my code, particularly in hard-to-understand areas
-   [n/a] I have made corresponding changes to the documentation, including updating the README with app information changes
-   [X] My changes generate no new warnings
-   [n/a] I have added tests that prove my fix is effective or that my feature works
-   [X] New and existing tests pass locally with my changes
-   [n/a] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

-   [X] [Version has been bumped](https://semver.org/) in `kbase.yml`
-   [X] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
