### PR TITLE
Making genome_refs optional for sequence set upload

### DIFF
--- a/ui/narrative/methods/import_fasta_as_seqset_from_staging/spec.json
+++ b/ui/narrative/methods/import_fasta_as_seqset_from_staging/spec.json
@@ -29,8 +29,8 @@
 				"KBaseGenomes.Genome","KBaseSearch.GenomeSet"
 			]
 		},
-		"optional" : false,
-		"advanced" : false,
+		"optional" : true,
+		"advanced" : true,
 		"allow_multiple" : true
     },
     {


### PR DESCRIPTION

Making genome_refs optional for sequence set upload