### PR TITLE
PUBLIC-2378 update docs links, link targets

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 ###Release Notes
 
+**1.0.59**
+modify links to all have `target="_blank"` for consistency (some did, many didn't).  
+update links to the docs site for uploading and downloading data.  
+
 **1.0.58**
 added new apps and utilities to support sequence set import.
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.58
+    1.0.59
 
 owners:
-    [tgu2, slebras, gaprice, qzhang, dakota, dylan, chenry]
+    [tgu2, gaprice, qzhang, dakota, dylan, chenry]

--- a/ui/narrative/methods/batch_import_assembly_from_staging/display.yaml
+++ b/ui/narrative/methods/batch_import_assembly_from_staging/display.yaml
@@ -46,6 +46,6 @@ parameters :
 
 description : |
     <p> Import files (FASTA) from your staging area into your Narrative as an Assembly data object.
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/batch_import_genome_from_staging/display.yaml
+++ b/ui/narrative/methods/batch_import_genome_from_staging/display.yaml
@@ -77,6 +77,6 @@ parameters :
 
 description : |
     <p> Import files (GenBank or GFF + FASTA) from your staging area into your Narrative as a Genome data object.
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/import_attribute_mapping_from_staging/display.yaml
+++ b/ui/narrative/methods/import_attribute_mapping_from_staging/display.yaml
@@ -36,7 +36,7 @@ parameters :
 
 description : |
     <p> Import a TSV or Excel file from your staging area into your Narrative as an Attribute Mapping data object.
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 publications :
     -

--- a/ui/narrative/methods/import_eschermap_from_staging/display.yaml
+++ b/ui/narrative/methods/import_eschermap_from_staging/display.yaml
@@ -36,4 +36,4 @@ parameters :
 
 description : |
     <p> Import a JSON file from your staging area into your Narrative as an KBaseFBA.EscherMap data object.
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>

--- a/ui/narrative/methods/import_fasta_as_assembly_from_staging/display.yaml
+++ b/ui/narrative/methods/import_fasta_as_assembly_from_staging/display.yaml
@@ -49,4 +49,4 @@ parameters :
 
 description : |
     <p> Import a FASTA file from your staging area into your Narrative as an Assembly data object.
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>

--- a/ui/narrative/methods/import_fasta_as_seqset_from_staging/display.yaml
+++ b/ui/narrative/methods/import_fasta_as_seqset_from_staging/display.yaml
@@ -65,4 +65,4 @@ parameters :
 
 description : |
     <p> Import a FASTA file from your staging area into your Narrative as a Protein/DNA Sequence Set data object.
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>

--- a/ui/narrative/methods/import_fastq_interleaved_as_reads_from_staging/display.yaml
+++ b/ui/narrative/methods/import_fastq_interleaved_as_reads_from_staging/display.yaml
@@ -65,6 +65,6 @@ parameters :
 
 description : |
     <p> Import a Interleaved FASTQ file from your staging area into your Narrative as an Assembly data object.
-    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/import_fastq_noninterleaved_as_reads_from_staging/display.yaml
+++ b/ui/narrative/methods/import_fastq_noninterleaved_as_reads_from_staging/display.yaml
@@ -65,6 +65,6 @@ parameters :
 
 description : |
     <p> Import a NonInterleaved FASTQ file into your Narrative as a Reads data object
-    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/import_fastq_sra_as_reads_from_staging/display.yaml
+++ b/ui/narrative/methods/import_fastq_sra_as_reads_from_staging/display.yaml
@@ -79,6 +79,6 @@ parameters :
 
 description : |
     <p> Import a FASTQ/SRA file into your Narrative as a Reads data object
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/import_file_as_fba_model_from_staging/display.yaml
+++ b/ui/narrative/methods/import_file_as_fba_model_from_staging/display.yaml
@@ -64,4 +64,4 @@ parameters :
 
 description : |
     <p>Import a file in TSV, XLS (Excel) or SBML format from your staging area into your Narrative as an FBAModel.
-        Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+        Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>

--- a/ui/narrative/methods/import_genbank_as_genome_from_staging/display.yaml
+++ b/ui/narrative/methods/import_genbank_as_genome_from_staging/display.yaml
@@ -93,4 +93,4 @@ parameters :
 
 description : |
     <p> Import a GenBank file from your staging area into your Narrative as a Genome data object.
-        Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+        Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>

--- a/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/display.yaml
+++ b/ui/narrative/methods/import_gff_fasta_as_genome_from_staging/display.yaml
@@ -94,6 +94,6 @@ parameters :
 
 description : |
     <p> Import a GFF or FASTA file from your staging area into your Narrative as a Genome data object.
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/import_gff_fasta_as_metagenome_from_staging/display.yaml
+++ b/ui/narrative/methods/import_gff_fasta_as_metagenome_from_staging/display.yaml
@@ -74,6 +74,6 @@ parameters :
 
 description : |
     <p> Import a GFF or FASTA file from your staging area into your Narrative as a Genome data object.
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/import_sra_as_reads_from_staging/display.yaml
+++ b/ui/narrative/methods/import_sra_as_reads_from_staging/display.yaml
@@ -58,6 +58,6 @@ parameters :
 
 description : |
     <p> Import a SRA file from your staging area into your Narrative as READS data object.
-    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/import_sra_as_reads_from_web/display.yaml
+++ b/ui/narrative/methods/import_sra_as_reads_from_web/display.yaml
@@ -58,13 +58,13 @@ parameter-groups :
         short-hint : SRA file URL and output Reads file name.
 
 description : |
-    <p>This App allows the user to load SRA format read libraries directly into the workspace from sources on the web. In addition to standard HTTP and anonymous FTP links, the user may also obtain files from Google drive and Dropbox links. Please see the <a href="http://kbase.us/data-upload-download-guide/short-reads//">FASTQ/SRA Reads Data Upload/Download Guide</a> for more information about SRA reads libraries.</p>
+    <p>This App allows the user to load SRA format read libraries directly into the workspace from sources on the web. In addition to standard HTTP and anonymous FTP links, the user may also obtain files from Google drive and Dropbox links. Please see the <a href="https://docs.kbase.us/data/upload-download-guide/reads" target="_blank">FASTQ/SRA Reads Data Upload/Download Guide</a> for more information about SRA reads libraries.</p>
 
     <p><strong>Using the app</strong><br>The user must inform KBase about the nature of the URL link by selecting one of the choices in the “URL Type” pulldown menu.  “Direct” means the link is a standard WWW URL, “FTP link” means anonymous FTP, and “Dropbox” and “Google Drive” Public Shared Links are for shared files in those two sources (see below for more instructions in those two cases).</p>
 
     <p> Once the link type is selected, the user can enter one or more URL links of that type. For each link, hit the “+” button to open a new sub-panel for the link. In each sub-panel, mandatory or required entries are indicated by a red vertical bar on the right. The first entry field takes the actual web link URL (by typing or pasting). The second is the object name you want to give to the reads object once it is loaded into KBase. The third mandatory field is a checkbox indicating whether or not the reads belong to a single genome. The remaining optional information are metadata describing the reads. More detail can be found under the hints for each field.</p>
 
-    <p>If your reads are in a publicly accessible URL, you can directly import the reads into your Narrative using either this App, the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/load_paired_end_reads_from_URL/release”>Import Paired-End Reads from Web</a> App, or the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/load_single_end_reads_from_URL/release”>Import Single-End Reads from Web</a> Apps.</p>
+    <p>If your reads are in a publicly accessible URL, you can directly import the reads into your Narrative using either this App, the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/load_paired_end_reads_from_URL/release” target="_blank">Import Paired-End Reads from Web</a> App, or the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/load_single_end_reads_from_URL/release” target="_blank">Import Single-End Reads from Web</a> Apps.</p>
 
     <p><u>How to Use a ‘Google Drive Public Shared Link’</u><br>In the source location in Google Drive:
       <ol>

--- a/ui/narrative/methods/import_tsv_as_expression_matrix_from_staging/display.yaml
+++ b/ui/narrative/methods/import_tsv_as_expression_matrix_from_staging/display.yaml
@@ -54,8 +54,8 @@ parameters :
 description : |
     <p> Import TSV File as Expression Matrix From Staging Area </p><br>
     <p>This uploader enables you to upload a gene expression data matrix in TSV (Tab-Separated Values) format.</p><br>
-    <p> The .tsv file is a tab-delimited text file, with genes down the rows and sample/observations across the columns (see <a href="http://kbase.us/data-upload-download-guide/expression-matrix/"" target="_blank">http://kbase.us/data-upload-download-guide/expression-matrix/</a> for more information). Make sure the first label in the first column
+    <p> The .tsv file is a tab-delimited text file, with genes down the rows and sample/observations across the columns (see <a href="https://docs.kbase.us/data/upload-download-guide/expression-matrix" target="_blank">https://docs.kbase.us/data/upload-download-guide/expression-matrix</a> for more information). Make sure the first label in the first column
     is "gene-id" followed by tab-delimited labels for samples. Each row (gene) should have an identifier (in green) that always goes in the first column. Each column
     (sample) should have a label (in blue) that is always in the first row. The remaining cells in the table contain expression values for the appropriate gene and sample.
     Be sure to exclude gene features for which all expressions are missing or are the same for all the conditions/samples.  See the
-    <a href="http://kbase.us/data-upload-download-guide/" target="_blank">Data Upload and Download Guide</a> for more information about formatting your expression data file.</p>
+    <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload and Download Guide</a> for more information about formatting your expression data file.</p>

--- a/ui/narrative/methods/import_tsv_excel_as_media_from_staging/display.yaml
+++ b/ui/narrative/methods/import_tsv_excel_as_media_from_staging/display.yaml
@@ -34,4 +34,4 @@ parameters :
 
 description : |
     <p> Import Media file (TSV/Excel) from Staging Area
-        Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+        Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>

--- a/ui/narrative/methods/load_paired_end_reads_from_URL/display.yaml
+++ b/ui/narrative/methods/load_paired_end_reads_from_URL/display.yaml
@@ -63,9 +63,9 @@ parameter-groups :
         short-hint : FASTQ file URL and output reads filename.
 
 description : |
-    <p>This App allows users to load FASTQ format paired-end read libraries directly into the workspace from sources on the web. In addition to standard HTTP and anonymous FTP links, the user may also obtain files from Google drive and Dropbox links. Please see the <a href="http://kbase.us/data-upload-download-guide/short-reads//">FASTQ/SRA Reads Data Upload/Download Guide</a> for more information.</p>
+    <p>This App allows users to load FASTQ format paired-end read libraries directly into the workspace from sources on the web. In addition to standard HTTP and anonymous FTP links, the user may also obtain files from Google drive and Dropbox links. Please see the <a href="https://docs.kbase.us/data/upload-download-guide/reads" target="_blank">FASTQ/SRA Reads Data Upload/Download Guide</a> for more information.</p>
 
-    <p>If your reads are in a publicly accessible URL, you can directly import the reads into your Narrative using either this App, the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/load_single_end_reads_from_URL/release”>Import Single-End Reads from Web</a> App, or <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/import_sra_as_reads_from_web/release”>Import SRA File as Reads from Web</a>the App.</p>
+    <p>If your reads are in a publicly accessible URL, you can directly import the reads into your Narrative using either this App, the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/load_single_end_reads_from_URL/release” target="_blank">Import Single-End Reads from Web</a> App, or <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/import_sra_as_reads_from_web/release” target="_blank">Import SRA File as Reads from Web</a>the App.</p>
 
     <p><u>How to Use a ‘Google Drive Public Shared Link’</u><br>In the source location in Google Drive:
       <ol>

--- a/ui/narrative/methods/load_paired_end_reads_from_file/display.yaml
+++ b/ui/narrative/methods/load_paired_end_reads_from_file/display.yaml
@@ -64,6 +64,6 @@ parameters :
 
 description : |
     <p> Import Paired-End Reads from Staging Area
-    Please see the <a href="http://kbase.us/data-upload-download-guide/">Data Upload/Download Guide</a> for more information. </p>
+    Please see the <a href="https://docs.kbase.us/data/upload-download-guide/" target="_blank">Data Upload/Download Guide</a> for more information. </p>
 
 technical-description : none

--- a/ui/narrative/methods/load_single_end_reads_from_URL/display.yaml
+++ b/ui/narrative/methods/load_single_end_reads_from_URL/display.yaml
@@ -46,9 +46,9 @@ parameter-groups :
         short-hint : FASTQ file URL and output Reads file name.
 
 description : |
-    <p>This App allows users to load FASTQ format single-end read libraries directly into the workspace from sources on the web. In addition to standard HTTP and anonymous FTP links, the user may also obtain files from Google drive and Dropbox links. Please see the <a href="http://kbase.us/data-upload-download-guide/short-reads//">FASTQ/SRA Reads Data Upload/Download Guide</a> for more information.</p>
+    <p>This App allows users to load FASTQ format single-end read libraries directly into the workspace from sources on the web. In addition to standard HTTP and anonymous FTP links, the user may also obtain files from Google drive and Dropbox links. Please see the <a href="https://docs.kbase.us/data/upload-download-guide/reads" target="_blank">FASTQ/SRA Reads Data Upload/Download Guide</a> for more information.</p>
 
-    <p>If your reads are in a publicly accessible URL, you can  directly import the reads into your Narrative using either this App, the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/load_paired_end_reads_from_URL/release”>Import Paired-End Reads from Web</a> App, or the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/import_sra_as_reads_from_web/release”>Import SRA File as Reads from Web</a>App.</p>
+    <p>If your reads are in a publicly accessible URL, you can  directly import the reads into your Narrative using either this App, the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/load_paired_end_reads_from_URL/release” target="_blank">Import Paired-End Reads from Web</a> App, or the <a href=”https://narrative.kbase.us/#catalog/apps/kb_uploadmethods/import_sra_as_reads_from_web/release” target="_blank">Import SRA File as Reads from Web</a>App.</p>
 
     <p><u>How to Use a ‘Google Drive Public Shared Link’</u><br>In the source location in Google Drive:
       <ol>


### PR DESCRIPTION
# Description of PR purpose/changes

This updates all the docs links from the old `http://www.kbase.us/data-upload-download-guide` to the new `https://docs.kbase.us/data/upload-download-guide/`. It also adds an external link target to those links to prevent accidentally navigating out of a narrative and possibly losing work.

It also removes `slebras` from the "owners" list of this module.

# Jira Ticket / Issue

https://kbase-jira.atlassian.net/browse/PUBLIC-2378

-   [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions

-   Details for how to test the PR: 
-   [x] Tests pass in Travis-CI and locally 

# Dev Checklist:

-   [x] My code follows the guidelines at <https://sites.google.com/truss.works/kbasetruss/development>
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation, including updating the README with app information changes
-   [x] My changes generate no new warnings
-   [n/a] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

-   [x] [Version has been bumped](https://semver.org/) in `kbase.yml`
-   [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
